### PR TITLE
Add emote exceptions for !slapyou

### DIFF
--- a/slapyou_tsm_theoddone.js
+++ b/slapyou_tsm_theoddone.js
@@ -9,10 +9,27 @@
  */
 
 /* Any accounts similar to OddOne's name have a 100% failure rate using !slapyou */
-const imposters = ["tsmthegodone"];
-const immuneresponse = ["Treason shall not be tolerated oddoneVillain ", "You fools! TheOddOne cannot be touched oddoneW", "TheOddOne is far too powerful to be slapped oddoneBakana"];
-const goodcrit = ["POGGERS", "PogChamp", "PagChomp"];
-const badcrit = ["Pepega", "POOGERS", "FeelsTastyMan", "OMEGALUL", "LUL", "PepeLaugh"];
+const imposters = [
+    "tsmthegodone"
+];
+const immuneresponse = [
+    "Treason shall not be tolerated oddoneVillain ",
+    "You fools! TheOddOne cannot be touched oddoneW",
+    "TheOddOne is far too powerful to be slapped oddoneBakana"
+];
+const goodcrit = [
+    "POGGERS",
+    "PogChamp",
+    "PagChomp"
+];
+const badcrit = [
+    "Pepega",
+    "POOGERS",
+    "FeelsTastyMan",
+    "OMEGALUL",
+    "LUL",
+    "PepeLaugh"
+];
 
 /**
  * C# style String.format
@@ -34,6 +51,13 @@ function slapyou(from, to) {
     let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
     let selfRegex = /^((.*self)|(.*selves))$/i;
     let oddone = from.toLowerCase() === "tsm_theoddone";
+
+    let emoteRegex = new Map();
+    emoteRegex.set(/(oddone7)|(oddoneAYAYA)|(oddoneBully)|(oddoneChair)|(oddoneClown)|(oddoneCop)/gi, "");
+    emoteRegex.set(/(oddoneCute)|(oddoneDiplomacy)|(oddoneDuel)|(oddoneFE)|(oddoneGhost)|(oddoneGreen)/gi, "");
+    emoteRegex.set(/(oddoneLOL)|(oddoneLick)|(oddoneOKO)|(oddonePOG)|(oddonePat)|(oddoneREE)|(oddoneRIP)/gi, "");
+    emoteRegex.set(/(oddoneShrug)|(oddoneSiSenor)|(oddoneSip)|(oddoneWeird)|(oddoneWel)|(oddAYAYA)|(oddCute)/gi, "");
+    emoteRegex.set(/(oddHYPERS)|(oddoneHeh)|(oddoneSmug)|(oddOwO)|(oddREE)|(oddSip)|(oddSlain)|(oddThump)|(oddWeeb)/gi, "");
 
     let leetMap = new Map();
     /* leetMap.set(/4|(\/[-_=+]+\\)|@|\^/g, "A");
@@ -65,12 +89,16 @@ function slapyou(from, to) {
         return "ERROR: You cannot attempt to intentionally slap yourself PepeLaugh ";
     }
 
-    let antileet = to;
-    for (let [key, value] of leetMap) {
-        antileet = antileet.replace(key, value);
+    let anti = to;
+    for (let [key, value] of emoteRegex) {
+        anti = anti.replace(key, value);
     }
 
-    if (!(antileet.match(oddoneRegex) === null)) {
+    for (let [key, value] of leetMap) {
+        anti = anti.replace(key, value);
+    }
+
+    if (!(anti.match(oddoneRegex) === null)) {
         if (crit) {
             return String.format("{0} attempted to slap TheOddOne, but was struck down and lost {1} EXP! oddoneVillain ", from, critexp.toString());
         } else {

--- a/slapyou_tsm_theoddone.js
+++ b/slapyou_tsm_theoddone.js
@@ -51,13 +51,60 @@ function slapyou(from, to) {
     let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
     let selfRegex = /^((.*self)|(.*selves))$/i;
     let oddone = from.toLowerCase() === "tsm_theoddone";
+    let splits = to.split(/\s/);
 
-    let emoteRegex = new Map();
-    emoteRegex.set(/(oddone7)|(oddoneAYAYA)|(oddoneBully)|(oddoneChair)|(oddoneClown)|(oddoneCop)/gi, "");
-    emoteRegex.set(/(oddoneCute)|(oddoneDiplomacy)|(oddoneDuel)|(oddoneFE)|(oddoneGhost)|(oddoneGreen)/gi, "");
-    emoteRegex.set(/(oddoneLOL)|(oddoneLick)|(oddoneOKO)|(oddonePOG)|(oddonePat)|(oddoneREE)|(oddoneRIP)/gi, "");
-    emoteRegex.set(/(oddoneShrug)|(oddoneSiSenor)|(oddoneSip)|(oddoneWeird)|(oddoneWel)|(oddAYAYA)|(oddCute)/gi, "");
-    emoteRegex.set(/(oddHYPERS)|(oddoneHeh)|(oddoneSmug)|(oddOwO)|(oddREE)|(oddSip)|(oddSlain)|(oddThump)|(oddWeeb)/gi, "");
+    let emoteSet = new Set();
+    
+    emoteSet.add("oddone7");
+    emoteSet.add("oddoneAYAYA");
+    emoteSet.add("oddoneBully");
+    emoteSet.add("oddoneChair");
+    emoteSet.add("oddoneClown");
+    emoteSet.add("oddoneCop");
+    emoteSet.add("oddoneCute");
+    emoteSet.add("oddoneDiplomacy");
+    emoteSet.add("oddoneDuel");
+    emoteSet.add("oddoneFE");
+    emoteSet.add("oddoneGhost");
+    emoteSet.add("oddoneGreen");
+    emoteSet.add("oddoneLOL");
+    emoteSet.add("oddoneLick");
+    emoteSet.add("oddoneOKO");
+    emoteSet.add("oddonePOG");
+    emoteSet.add("oddonePat");
+    emoteSet.add("oddoneREE");
+    emoteSet.add("oddoneRIP");
+    emoteSet.add("oddoneShrug");
+    emoteSet.add("oddoneSiSenor");
+    emoteSet.add("oddoneSip");
+    emoteSet.add("oddoneWeird");
+    emoteSet.add("oddoneWel");
+    emoteSet.add("oddAYAYA");
+    emoteSet.add("oddCute");
+    emoteSet.add("oddHYPERS");
+    emoteSet.add("oddoneHeh");
+    emoteSet.add("oddoneSmug");
+    emoteSet.add("oddOwO");
+    emoteSet.add("oddREE");
+    emoteSet.add("oddSip");
+    emoteSet.add("oddSlain");
+    emoteSet.add("oddThump");
+    emoteSet.add("oddWeeb");
+
+    for (let idx = 0; idx < splits.length; ++idx) {
+        let curr = splits[idx];
+        if (emoteSet.has(curr)) {
+            splits[idx] = "";
+        }
+    }
+
+    let anti = "";
+
+    splits.forEach(word => {
+        if (word.length > 0) {
+            anti = anti.concat(" " + word);
+        }
+    })
 
     let leetMap = new Map();
     /* leetMap.set(/4|(\/[-_=+]+\\)|@|\^/g, "A");
@@ -87,11 +134,6 @@ function slapyou(from, to) {
 
     if (from === to | !(to.match(selfRegex) === null)) {
         return "ERROR: You cannot attempt to intentionally slap yourself PepeLaugh ";
-    }
-
-    let anti = to;
-    for (let [key, value] of emoteRegex) {
-        anti = anti.replace(key, value);
     }
 
     for (let [key, value] of leetMap) {

--- a/slapyou_tsm_theoddone.js
+++ b/slapyou_tsm_theoddone.js
@@ -51,7 +51,7 @@ function slapyou(from, to) {
     let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
     let selfRegex = /^((.*self)|(.*selves))$/i;
     let oddone = from.toLowerCase() === "tsm_theoddone";
-    let splits = to.split(/\s/);
+    let splits = to.split(/\s+/);
 
     let emoteSet = new Set();
     
@@ -91,6 +91,8 @@ function slapyou(from, to) {
     emoteSet.add("oddThump");
     emoteSet.add("oddWeeb");
 
+    let anti = "";
+
     for (let idx = 0; idx < splits.length; ++idx) {
         let curr = splits[idx];
         if (emoteSet.has(curr)) {
@@ -98,13 +100,11 @@ function slapyou(from, to) {
         }
     }
 
-    let anti = "";
-
     splits.forEach(word => {
         if (word.length > 0) {
             anti = anti.concat(" " + word);
         }
-    })
+    });
 
     let leetMap = new Map();
     /* leetMap.set(/4|(\/[-_=+]+\\)|@|\^/g, "A");

--- a/slapyou_tsm_theoddone.js
+++ b/slapyou_tsm_theoddone.js
@@ -48,7 +48,7 @@ function slapyou(from, to) {
     
     let crit = Math.random() < 0.0625;
     let critexp = Math.round(Math.random() * (1500 - 1001) + 1001);
-    let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
+    let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun|wiggle|weeb)(.*)$/i;
     let selfRegex = /^((.*self)|(.*selves))$/i;
     let oddone = from.toLowerCase() === "tsm_theoddone";
     let splits = to.split(/\s+/);
@@ -77,6 +77,7 @@ function slapyou(from, to) {
     emoteSet.add("oddoneShrug");
     emoteSet.add("oddoneSiSenor");
     emoteSet.add("oddoneSip");
+    emoteSet.add("oddoneSleeper");
     emoteSet.add("oddoneWeird");
     emoteSet.add("oddoneWel");
     emoteSet.add("oddAYAYA");
@@ -89,7 +90,6 @@ function slapyou(from, to) {
     emoteSet.add("oddSip");
     emoteSet.add("oddSlain");
     emoteSet.add("oddThump");
-    emoteSet.add("oddWeeb");
 
     let anti = "";
 

--- a/slapyou_tsm_theoddone.js
+++ b/slapyou_tsm_theoddone.js
@@ -31,8 +31,8 @@ function slapyou(from, to) {
     
     let crit = Math.random() < 0.0625;
     let critexp = Math.round(Math.random() * (1500 - 1001) + 1001);
-    let oddone_regex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
-    let self_regex = /^((.*self)|(.*selves))$/i;
+    let oddoneRegex = /^(.*odd|.*awd|.*god)(?=.*one|.*juan|.*wan|.*1|.*wun)(.*)$/i;
+    let selfRegex = /^((.*self)|(.*selves))$/i;
     let oddone = from.toLowerCase() === "tsm_theoddone";
 
     let leetMap = new Map();
@@ -61,7 +61,7 @@ function slapyou(from, to) {
     leetMap.set(/></g, "X");
     leetMap.set(/2/g, "Z"); */
 
-    if (from === to | !(to.match(self_regex) === null)) {
+    if (from === to | !(to.match(selfRegex) === null)) {
         return "ERROR: You cannot attempt to intentionally slap yourself PepeLaugh ";
     }
 
@@ -70,7 +70,7 @@ function slapyou(from, to) {
         antileet = antileet.replace(key, value);
     }
 
-    if (!(antileet.match(oddone_regex) === null)) {
+    if (!(antileet.match(oddoneRegex) === null)) {
         if (crit) {
             return String.format("{0} attempted to slap TheOddOne, but was struck down and lost {1} EXP! oddoneVillain ", from, critexp.toString());
         } else {


### PR DESCRIPTION
OddOne's emotes are now allowed when using !slapyou. Certain emotes that would represent him are blocked, which are as follows:

- oddoneBakana
- oddoneRAGE
- oddoneTheGeneral
- oddoneVillain
- oddoneW
- oddoneWOOW
- oddWeeb
- oddWriggle
